### PR TITLE
Update to use the new *-scm and *-curl buildpack-deps variants

### DIFF
--- a/openjdk-6-jdk/Dockerfile
+++ b/openjdk-6-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:wheezy-micro
+FROM buildpack-deps:wheezy-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:wheezy-micro
+FROM buildpack-deps:wheezy-curl
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/openjdk-7-jdk/Dockerfile
+++ b/openjdk-7-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie-micro
+FROM buildpack-deps:jessie-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie-micro
+FROM buildpack-deps:jessie-curl
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:sid-micro
+FROM buildpack-deps:sid-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:sid-micro
+FROM buildpack-deps:sid-curl
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.


### PR DESCRIPTION
See https://github.com/docker-library/official-images/pull/413.