### PR TITLE
Apply ca-certificates-java workaround for now (https://bugs.debian.org/775775)

### DIFF
--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -10,7 +10,14 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 ENV JAVA_VERSION 8u40~b09
 ENV JAVA_DEBIAN_VERSION 8u40~b09-1
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+# see https://bugs.debian.org/775775
+# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+
+RUN apt-get update && apt-get install -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
+
+# see CA_CERTIFICATES_JAVA_VERSION notes above
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -10,7 +10,14 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 ENV JAVA_VERSION 8u40~b09
 ENV JAVA_DEBIAN_VERSION 8u40~b09-1
 
-RUN apt-get update && apt-get install -y openjdk-8-jre="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+# see https://bugs.debian.org/775775
+# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+
+RUN apt-get update && apt-get install -y openjdk-8-jre="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
+
+# see CA_CERTIFICATES_JAVA_VERSION notes above
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!


### PR DESCRIPTION
Fixes #19