### PR TITLE
Use openjdk-*-jre-headless packages for jre images

### DIFF
--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 ENV JAVA_VERSION 6b33
 ENV JAVA_DEBIAN_VERSION 6b33-1.13.5-2~deb7u1
 
-RUN apt-get update && apt-get install -y openjdk-6-jre="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 ENV JAVA_VERSION 7u71
 ENV JAVA_DEBIAN_VERSION 7u71-2.5.3-2
 
-RUN apt-get update && apt-get install -y openjdk-7-jre="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_DEBIAN_VERSION 8u40~b09-1
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 ENV CA_CERTIFICATES_JAVA_VERSION 20140324
 
-RUN apt-get update && apt-get install -y openjdk-8-jre="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure


### PR DESCRIPTION
Figured I may as well create a PR for this change. Feel free to close if you're not interested.

Fixes #21