### PR TITLE
Use Debian Jessie as base image for Java 8

### DIFF
--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:sid-scm
+FROM buildpack-deps:jessie-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -7,11 +7,13 @@ FROM buildpack-deps:sid-scm
 
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
+
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
 ENV JAVA_VERSION 8u45
-ENV JAVA_DEBIAN_VERSION 8u45-b14-3
+ENV JAVA_DEBIAN_VERSION 8u45-b14-2~bpo8+2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -19,7 +19,12 @@ ENV JAVA_DEBIAN_VERSION 8u45-b14-2~bpo8+2
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 ENV CA_CERTIFICATES_JAVA_VERSION 20140324
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
+		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -19,7 +19,12 @@ ENV JAVA_DEBIAN_VERSION 8u45-b14-2~bpo8+2
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 ENV CA_CERTIFICATES_JAVA_VERSION 20140324
 
-RUN apt-get update && apt-get install -y openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
+		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:sid-curl
+FROM buildpack-deps:jessie-curl
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -7,11 +7,13 @@ FROM buildpack-deps:sid-curl
 
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
+
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
 ENV JAVA_VERSION 8u45
-ENV JAVA_DEBIAN_VERSION 8u45-b14-3
+ENV JAVA_DEBIAN_VERSION 8u45-b14-2~bpo8+2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872

--- a/update.sh
+++ b/update.sh
@@ -16,8 +16,14 @@ for version in "${versions[@]}"; do
 	javaType="${javaVersion##*-}" # "jdk"
 	javaVersion="${javaVersion%-*}" # "6"
 	
-	dist="$(grep '^FROM ' "$version/Dockerfile" | cut -d' ' -f2)"
-	
+	# Determine debian:SUITE based on FROM directive
+	dist="$(grep '^FROM ' "$version/Dockerfile" | cut -d' ' -f2 | sed -r 's/^buildpack-deps:(\w+)-.*$/debian:\1/')"
+
+	# Use debian:SUITE-backports if backports packages are required
+	if grep -q backports "$version/Dockerfile"; then
+		dist+="-backports"
+	fi
+
 	fullVersion=
 	case "$flavor" in
 		openjdk)
@@ -25,7 +31,7 @@ for version in "${versions[@]}"; do
 			fullVersion="${debianVersion%%-*}"
 			;;
 	esac
-	
+
 	if [ "$fullVersion" ]; then
 		(
 			set -x


### PR DESCRIPTION
This PR uses [jessie-backports](http://backports.debian.org/changes/jessie-backports.html) to get OpenJDK 8 under Debian Jessie.

I haven't yet made the necessary updates to `update.sh` since it's a bit tricky. The `docker run` statement that's used to check `apt-cache show` will need to conditionally add a Apt source list for `jessie-backports`. I could make it work, but it's going to be a hack.