### PR TITLE
Move the "latest" tag to point to "java:8"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,8 +3,8 @@ set -e
 
 declare -A aliases
 aliases=(
-	[openjdk-7-jdk]='jdk latest'
-	[openjdk-7-jre]='jre'
+	[openjdk-8-jdk]='jdk latest'
+	[openjdk-8-jre]='jre'
 )
 defaultType='jdk'
 defaultFlavor='openjdk'


### PR DESCRIPTION
Also updates "jdk" and "jre" to point to their respective Java 8 version

Background discussion can be found in #43 