### PR TITLE
Add explicit JAVA_HOME environment variable

### DIFF
--- a/openjdk-6-jdk/Dockerfile
+++ b/openjdk-6-jdk/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
+
 ENV JAVA_VERSION 6b36
 ENV JAVA_DEBIAN_VERSION 6b36-1.13.8-1~deb7u1
 

--- a/openjdk-6-jdk/Dockerfile
+++ b/openjdk-6-jdk/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:wheezy-scm
 
 # A few problems with compiling Java from source:
@@ -15,7 +21,11 @@ ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
 ENV JAVA_VERSION 6b36
 ENV JAVA_DEBIAN_VERSION 6b36-1.13.8-1~deb7u1
 
-RUN apt-get update && apt-get install -y openjdk-6-jdk="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-6-jdk/Dockerfile
+++ b/openjdk-6-jdk/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
 
 ENV JAVA_VERSION 6b36
@@ -25,7 +35,8 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y \
 		openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/jre
 
 ENV JAVA_VERSION 6b36
@@ -25,7 +35,8 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y \
 		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
+
 ENV JAVA_VERSION 6b36
 ENV JAVA_DEBIAN_VERSION 6b36-1.13.8-1~deb7u1
 

--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:wheezy-curl
 
 # A few problems with compiling Java from source:
@@ -10,12 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/jre
 
 ENV JAVA_VERSION 6b36
 ENV JAVA_DEBIAN_VERSION 6b36-1.13.8-1~deb7u1
 
-RUN apt-get update && apt-get install -y openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-7-jdk/Dockerfile
+++ b/openjdk-7-jdk/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
 ENV JAVA_VERSION 7u91
 ENV JAVA_DEBIAN_VERSION 7u91-2.6.3-1~deb8u1
 

--- a/openjdk-7-jdk/Dockerfile
+++ b/openjdk-7-jdk/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ENV JAVA_VERSION 7u91
@@ -25,7 +35,8 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y \
 		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-7-jdk/Dockerfile
+++ b/openjdk-7-jdk/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:jessie-scm
 
 # A few problems with compiling Java from source:
@@ -15,7 +21,11 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 ENV JAVA_VERSION 7u91
 ENV JAVA_DEBIAN_VERSION 7u91-2.6.3-1~deb8u1
 
-RUN apt-get update && apt-get install -y openjdk-7-jdk="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
 ENV JAVA_VERSION 7u91
 ENV JAVA_DEBIAN_VERSION 7u91-2.6.3-1~deb8u1
 

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:jessie-curl
 
 # A few problems with compiling Java from source:
@@ -10,12 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 
 ENV JAVA_VERSION 7u91
 ENV JAVA_DEBIAN_VERSION 7u91-2.6.3-1~deb8u1
 
-RUN apt-get update && apt-get install -y openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 
 ENV JAVA_VERSION 7u91
@@ -25,7 +35,8 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y \
 		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -18,6 +18,16 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 ENV JAVA_VERSION 8u66
@@ -32,7 +42,8 @@ RUN set -x \
 	&& apt-get install -y \
 		openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -12,6 +12,8 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 ENV JAVA_VERSION 8u66
 ENV JAVA_DEBIAN_VERSION 8u66-b17-1~bpo8+1
 

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:jessie-scm
 
 # A few problems with compiling Java from source:

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -12,6 +12,8 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 ENV JAVA_VERSION 8u66
 ENV JAVA_DEBIAN_VERSION 8u66-b17-1~bpo8+1
 

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -18,6 +18,16 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
 ENV JAVA_VERSION 8u66
@@ -32,7 +42,8 @@ RUN set -x \
 	&& apt-get install -y \
 		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:jessie-curl
 
 # A few problems with compiling Java from source:
@@ -12,7 +18,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
 ENV JAVA_VERSION 8u66
 ENV JAVA_DEBIAN_VERSION 8u66-b17-1~bpo8+1
@@ -30,10 +36,6 @@ RUN set -x \
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-# see https://bugs.debian.org/793210
-# and https://github.com/docker-library/java/issues/46#issuecomment-119026586
-RUN apt-get update && apt-get install -y --no-install-recommends libfontconfig1 && rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-9-jdk/Dockerfile
+++ b/openjdk-9-jdk/Dockerfile
@@ -18,6 +18,16 @@ RUN echo 'deb http://httpredir.debian.org/debian experimental main' > /etc/apt/s
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 
 ENV JAVA_VERSION 9~b96
@@ -32,7 +42,8 @@ RUN set -x \
 	&& apt-get install -y \
 		openjdk-9-jdk="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-9-jdk/Dockerfile
+++ b/openjdk-9-jdk/Dockerfile
@@ -1,4 +1,10 @@
-FROM buildpack-deps:sid-curl
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:sid-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -30,10 +36,6 @@ RUN set -x \
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-# see https://bugs.debian.org/793210
-# and https://github.com/docker-library/java/issues/46#issuecomment-119026586
-RUN apt-get update && apt-get install -y --no-install-recommends libfontconfig1 && rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-9-jdk/Dockerfile
+++ b/openjdk-9-jdk/Dockerfile
@@ -12,6 +12,8 @@ RUN echo 'deb http://httpredir.debian.org/debian experimental main' > /etc/apt/s
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
+
 ENV JAVA_VERSION 9~b96
 ENV JAVA_DEBIAN_VERSION 9~b96-1
 

--- a/openjdk-9-jre/Dockerfile
+++ b/openjdk-9-jre/Dockerfile
@@ -28,7 +28,7 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64/jre
+ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 
 ENV JAVA_VERSION 9~b96
 ENV JAVA_DEBIAN_VERSION 9~b96-1

--- a/openjdk-9-jre/Dockerfile
+++ b/openjdk-9-jre/Dockerfile
@@ -1,3 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM buildpack-deps:sid-curl
 
 # A few problems with compiling Java from source:
@@ -12,7 +18,7 @@ RUN echo 'deb http://httpredir.debian.org/debian experimental main' > /etc/apt/s
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64/jre
 
 ENV JAVA_VERSION 9~b96
 ENV JAVA_DEBIAN_VERSION 9~b96-1
@@ -30,10 +36,6 @@ RUN set -x \
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-# see https://bugs.debian.org/793210
-# and https://github.com/docker-library/java/issues/46#issuecomment-119026586
-RUN apt-get update && apt-get install -y --no-install-recommends libfontconfig1 && rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/openjdk-9-jre/Dockerfile
+++ b/openjdk-9-jre/Dockerfile
@@ -18,6 +18,16 @@ RUN echo 'deb http://httpredir.debian.org/debian experimental main' > /etc/apt/s
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/bash'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
 ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64/jre
 
 ENV JAVA_VERSION 9~b96
@@ -32,7 +42,8 @@ RUN set -x \
 	&& apt-get install -y \
 		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/openjdk-9-jre/Dockerfile
+++ b/openjdk-9-jre/Dockerfile
@@ -12,6 +12,8 @@ RUN echo 'deb http://httpredir.debian.org/debian experimental main' > /etc/apt/s
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
+
 ENV JAVA_VERSION 9~b96
 ENV JAVA_DEBIAN_VERSION 9~b96-1
 

--- a/update.sh
+++ b/update.sh
@@ -83,6 +83,22 @@ for version in "${versions[@]}"; do
 
 		# Default to UTF-8 file.encoding
 		ENV LANG C.UTF-8
+	EOD
+
+	cat >> "$version/Dockerfile" <<EOD
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \\
+		echo '#!/bin/bash'; \\
+		echo 'set -e'; \\
+		echo; \\
+		echo 'dirname "\$(dirname "\$(readlink -f "\$(which javac || which java)")")"'; \\
+	} > /usr/local/bin/docker-java-home \\
+	&& chmod +x /usr/local/bin/docker-java-home
+EOD
+
+	cat >> "$version/Dockerfile" <<-EOD
 
 		ENV JAVA_HOME $javaHome
 
@@ -112,7 +128,8 @@ EOD
 EOD
 	fi
 	cat >> "$version/Dockerfile" <<EOD
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \\
+	&& [ "\$JAVA_HOME" = "\$(docker-java-home)" ]
 EOD
 
 	if [ "$needCaHack" ]; then

--- a/update.sh
+++ b/update.sh
@@ -40,7 +40,8 @@ for version in "${versions[@]}"; do
 	variant="${variants[$javaType]}"
 
 	javaHome="/usr/lib/jvm/java-$javaVersion-$flavor-$(dpkg --print-architecture)"
-	if [ "$javaType" = 'jre' ]; then
+	if [ "$javaType" = 'jre' -a "$javaVersion" -lt 9 ]; then
+		# woot, this hackery stopped in OpenJDK 9+!
 		javaHome+='/jre'
 	fi
 

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,23 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
+declare -A suites=(
+	[openjdk-6]='wheezy'
+	[openjdk-7]='jessie'
+	[openjdk-8]='jessie'
+	[openjdk-9]='sid'
+)
+
+declare -A addSuites=(
+	[openjdk-8]='jessie-backports'
+	[openjdk-9]='experimental'
+)
+
+declare -A variants=(
+	[jre]='curl'
+	[jdk]='scm'
+)
+
 travisEnv=
 for version in "${versions[@]}"; do
 	flavor="${version%%-*}" # "openjdk"
@@ -16,36 +33,101 @@ for version in "${versions[@]}"; do
 	javaType="${javaVersion##*-}" # "jdk"
 	javaVersion="${javaVersion%-*}" # "6"
 
-	# Determine debian:SUITE based on FROM directive
-	dist="$(grep '^FROM ' "$version/Dockerfile" | cut -d' ' -f2 | sed -r 's/^buildpack-deps:(\w+)-.*$/debian:\1/')"
+	suite="${suites[$flavor-$javaVersion]}"
+	addSuite="${addSuites[$flavor-$javaVersion]}"
+	variant="${variants[$javaType]}"
 
-	# Use debian:SUITE-backports if backports packages are required
-	if grep -q backports "$version/Dockerfile"; then
-		dist+="-backports"
+	javaHome="/usr/lib/jvm/java-$javaVersion-$flavor-$(dpkg --print-architecture)"
+	if [ "$javaType" = 'jre' ]; then
+		javaHome+='/jre'
 	fi
 
-	# we don't have buildpack-deps:experimental-* so we use sid and add a source
-	if grep -q experimental "$version/Dockerfile"; then
-		dist="${dist%:sid}:experimental"
+	needCaHack=
+	if [ "$javaVersion" -ge 8 ]; then
+		needCaHack=1
 	fi
 
-	fullVersion=
-	case "$flavor" in
-		openjdk)
-			debianVersion="$(set -x; docker run --rm "$dist" bash -c "apt-get update -qq && apt-cache show $flavor-$javaVersion-$javaType | awk -F ': ' '\$1 == \"Version\" { print \$2; exit }'")"
-			fullVersion="${debianVersion%%-*}"
-			;;
-	esac
-
-	if [ "$fullVersion" ]; then
-		(
-			set -x
-			sed -ri '
-				s/(ENV JAVA_VERSION) .*/\1 '"$fullVersion"'/g;
-				s/(ENV JAVA_DEBIAN_VERSION) .*/\1 '"$debianVersion"'/g;
-			' "$version/Dockerfile"
-		)
+	dist="debian:${addSuite:-$suite}"
+	debianPackage="$flavor-$javaVersion-$javaType"
+	if [ "$javaType" = 'jre' ]; then
+		debianPackage+='-headless'
 	fi
+	debianVersion="$(set -x; docker run --rm "$dist" bash -c 'apt-get update -qq && apt-cache show "$@"' -- "$debianPackage" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
+	fullVersion="${debianVersion%%-*}"
+
+	cat > "$version/Dockerfile" <<-EOD
+		#
+		# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+		#
+		# PLEASE DO NOT EDIT IT DIRECTLY.
+		#
+
+		FROM buildpack-deps:$suite-$variant
+
+		# A few problems with compiling Java from source:
+		#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+		#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+		#       really hairy.
+
+		RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
+	EOD
+
+	if [ "$addSuite" ]; then
+		cat >> "$version/Dockerfile" <<-EOD
+
+			RUN echo 'deb http://httpredir.debian.org/debian $addSuite main' > /etc/apt/sources.list.d/$addSuite.list
+		EOD
+	fi
+
+	cat >> "$version/Dockerfile" <<-EOD
+
+		# Default to UTF-8 file.encoding
+		ENV LANG C.UTF-8
+
+		ENV JAVA_HOME $javaHome
+
+		ENV JAVA_VERSION $fullVersion
+		ENV JAVA_DEBIAN_VERSION $debianVersion
+	EOD
+
+	if [ "$needCaHack" ]; then
+		cat >> "$version/Dockerfile" <<-EOD
+
+			# see https://bugs.debian.org/775775
+			# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+			ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+		EOD
+	fi
+
+	cat >> "$version/Dockerfile" <<EOD
+
+RUN set -x \\
+	&& apt-get update \\
+	&& apt-get install -y \\
+		$debianPackage="\$JAVA_DEBIAN_VERSION" \\
+EOD
+	if [ "$needCaHack" ]; then
+		cat >> "$version/Dockerfile" <<EOD
+		ca-certificates-java="\$CA_CERTIFICATES_JAVA_VERSION" \\
+EOD
+	fi
+	cat >> "$version/Dockerfile" <<EOD
+	&& rm -rf /var/lib/apt/lists/*
+EOD
+
+	if [ "$needCaHack" ]; then
+		cat >> "$version/Dockerfile" <<-EOD
+
+			# see CA_CERTIFICATES_JAVA_VERSION notes above
+			RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+		EOD
+	fi
+
+	cat >> "$version/Dockerfile" <<-EOD
+
+		# If you're reading this and have any feedback on how this image could be
+		#   improved, please open an issue or a pull request so we can discuss it!
+	EOD
 
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 done


### PR DESCRIPTION
Closes #28 (commit carried/rebased here)
Fixes #27

For reference, the intended use-case of the "docker-java-home" script this installs is things like https://github.com/docker-library/tomcat/pull/19/files#diff-03f3e74233d756c542dc2d234fe3c43bR42, where we are `FROM` the JRE image, but install the JDK temporarily in order to compile something and then remove it again for size.